### PR TITLE
Fixes #2032: Removed Google+ share option from Settings->Share on Soc…

### DIFF
--- a/src/components/ChatApp/Settings/ShareOnSocialMedia.js
+++ b/src/components/ChatApp/Settings/ShareOnSocialMedia.js
@@ -95,24 +95,6 @@ const ShareOnSocialMedia = props => {
               }
             />
           </div>
-          <div style={props.headingStyle}>
-            <Translate text="Share about SUSI on Google+" />
-            <br />
-            <RaisedButton
-              label={<Translate text="Share on Google+" />}
-              style={raisedButtonStyle}
-              backgroundColor="#d34836"
-              labelColor="#fff"
-              icon={<FontIcon className="fa fa-google-plus" />}
-              keyboardFocused={false}
-              onClick={() =>
-                window.open(
-                  `https://plus.google.com/share?url=${urls.CHAT_URL}`,
-                  '_blank',
-                )
-              }
-            />
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
…ial Media.

Reason being no Google+ share option on Share tab from header scroll down list.
Erasing Google+ is a better solution since it is going to end its feature due 2nd April 2019.

Fixes #[Add issue number here. If you do not solve the issue entirely, please change the message e.g. "First steps for issues #IssueNumber]

Changes: [Add here what changes were made in this issue and if possible provide links.]

Demo Link: https://pr-[ADD_PULL_REQUEST_NUMBER_HERE]-fossasia-susi-web-chat.surge.sh

Screenshots for the change: 
